### PR TITLE
bugfix: make no <inherits> required in *.gwt.xml

### DIFF
--- a/gwt/api/src/main/resources/com/google/gwt/emul/java/util/ServiceLoader.java
+++ b/gwt/api/src/main/resources/com/google/gwt/emul/java/util/ServiceLoader.java
@@ -3,13 +3,14 @@ package java.util;
 
 import javax.inject.Provider;
 
-import xapi.util.api.ReceivesValue;
+// import xapi.util.api.ReceivesValue;
+// implements , ReceivesValue<Class<S>>
 
 import com.google.gwt.core.shared.GWT;
 
 
-public  class ServiceLoader<S>
-    implements Iterable<S>, ReceivesValue<Class<S>>
+public class ServiceLoader<S>
+    implements Iterable<S>
 {
 
     protected Provider<S> theProvider;


### PR DESCRIPTION
simple bugfix to make a dependency on xapi in a gwt project to not require inherits statements in gwt modules